### PR TITLE
py3 compatibility fixes

### DIFF
--- a/hsc/hsc_core_module.py
+++ b/hsc/hsc_core_module.py
@@ -32,7 +32,7 @@ class HSCCoreModule(object):
         self.lmax = self.saccs[0].binning.windows[0].w.shape[0]
         self.ells = np.arange(self.lmax)
 
-        if set(COSMO_PARAM_KEYS) <= set(DEFAULT_PARAMS.viewkeys()):
+        if set(COSMO_PARAM_KEYS) <= set(DEFAULT_PARAMS.keys()):
             FID_COSMO_PARAMS = self.get_params(DEFAULT_PARAMS, 'cosmo')
             logger.info('Not varying cosmological parameters. Fixing cosmology to fiducial values = {}.'.format(FID_COSMO_PARAMS))
             self.cosmo = ccl.Cosmology(**FID_COSMO_PARAMS)
@@ -62,7 +62,7 @@ class HSCCoreModule(object):
         cosmo_params = self.get_params(params, 'cosmo')
 
         try:
-            if (cosmo_params.viewkeys() & self.mapping.viewkeys()) != set([]):
+            if (cosmo_params.keys() & self.mapping.keys()) != set([]):
                 cosmo = ccl.Cosmology(**cosmo_params)
             else:
                 cosmo = self.cosmo

--- a/hsc/run_CosmoHammer.py
+++ b/hsc/run_CosmoHammer.py
@@ -201,18 +201,18 @@ for key in fit_params.keys():
     param_mapping[key] = fit_params[key][0]
     params[fit_params[key][0], :] = fit_params[key][1:]
 
-if set(BIAS_PARAM_BZ_KEYS) <= set(param_mapping.viewkeys()):
+if set(BIAS_PARAM_BZ_KEYS) <= set(param_mapping.keys()):
     logger.info('Fitting for galaxy bias with model = bz.')
     config['default_params']['z_b'] = z_b
 
-elif set(BIAS_PARAM_CONST_KEYS) <= set(param_mapping.viewkeys()):
+elif set(BIAS_PARAM_CONST_KEYS) <= set(param_mapping.keys()):
     logger.info('Fitting for galaxy bias with model = const.')
 
 else:
     assert 'bg' in cl_params, 'Not fitting for galaxy bias but no fiducial values provided. Aborting.'
     logger.info('Not fitting for galaxy bias.')
     config['default_params'].update(cl_params['bg'])
-    if set(BIAS_PARAM_BZ_KEYS) <= set(cl_params['bg'].viewkeys()):
+    if set(BIAS_PARAM_BZ_KEYS) <= set(cl_params['bg'].keys()):
         logger.info('Galaxy bias model = bz.')
         config['default_params']['z_b'] = z_b
 


### PR DESCRIPTION
Very simple PR, essentially just a few replacements of viewdict with dict. Should keep py27 compatibility, I think, but making a PR just in case you complain.